### PR TITLE
Update version pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN sudo pip install mkdocs-bootswatch==0.1.0
 RUN sudo pip install mkdocs-bootstrap==0.1.1
 RUN sudo pip install mkdocs==0.15.3
 RUN sudo pip install mkdocs-material==0.2.4
-RUN sudo pip install pymdown-extensions
+RUN sudo pip install pymdown-extensions==6.2.1
+
 EXPOSE 8080
 
 CMD ["mkdocs", "serve"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ mkdocs-bootswatch==0.1.0
 mkdocs-bootstrap==0.1.1
 mkdocs==0.15.3
 mkdocs-material==0.2.4
-pymdown-extensions
+pymdown-extensions==6.2.1


### PR DESCRIPTION
We need to pin to version 6.2.1 of `pymdown-extensions`